### PR TITLE
Fixing the initscript mostly

### DIFF
--- a/debian/postinst
+++ b/debian/postinst
@@ -11,7 +11,6 @@ fi
 
 if [ ! -e "${XDHOME}/xd.ini" ]; then
     cd $XDHOME && sudo -u $XDUSER XD --genconf ${XDHOME}/xd.ini
-    chown ${XDUSER}:${XDUSER} ${XDHOME}/xd.ini ${XDHOME}/trackers.ini
 fi
 
 #DEBHELPER#

--- a/debian/postinst
+++ b/debian/postinst
@@ -10,8 +10,8 @@ if [ "$1" != "configure" ]; then
 fi
 
 if [ ! -e "${XDHOME}/xd.ini" ]; then
-    cd $XDHOME && XD --genconf ${XDHOME}/xd.ini
-    chown -R ${XDUSER}:${XDUSER} ${XDHOME}
+    cd $XDHOME && sudo -u $XDUSER XD --genconf ${XDHOME}/xd.ini
+    chown ${XDUSER}:${XDUSER} ${XDHOME}/xd.ini ${XDHOME}/trackers.ini
 fi
 
 #DEBHELPER#

--- a/debian/postinst
+++ b/debian/postinst
@@ -10,7 +10,7 @@ if [ "$1" != "configure" ]; then
 fi
 
 if [ ! -e "${XDHOME}/xd.ini" ]; then
-    cd $XDHOME && sudo -u $XDUSER XD --genconf ${XDHOME}/xd.ini
+    cd $XDHOME && su -p $XDUSER -c "XD --genconf ${XDHOME}/xd.ini"
 fi
 
 #DEBHELPER#

--- a/debian/preinst
+++ b/debian/preinst
@@ -19,6 +19,7 @@ xdadduser() {
           --shell /bin/false \
           $XDUSER >/dev/null
     fi
+    install --directory --group=$XDUSER --owner=$XDUSER /var/run/XD -m644
 }
 
 case "$1" in

--- a/debian/xd.init
+++ b/debian/xd.init
@@ -14,7 +14,7 @@ PATH=/sbin:/usr/sbin:/bin:/usr/bin
 DESC="Standalone I2P BitTorrent Client"   # Introduce a short description here
 NAME=XD                   # Introduce the short server's name here
 DAEMON=/usr/bin/$NAME       # Introduce the server's location here
-PIDFILE=/var/run/$NAME.pid
+PIDFILE=/var/run/$NAME/$NAME.pid
 XDCONF=/etc/$NAME/xd.ini
 XDHOME=/var/lib/XD
 USER="debian-xd"
@@ -35,7 +35,7 @@ do_start()
 
   start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --chuid "$USER" --test > /dev/null \
     || return 1
-  start-stop-daemon --start --quiet --pidfile $PIDFILE --exec $DAEMON --chuid "$USER" --chdir $XDHOME -- \
+  start-stop-daemon --start --quiet --background --make-pidfile --pidfile $PIDFILE --exec $DAEMON --chuid "$USER" --chdir $XDHOME -- \
     $XDCONF > /dev/null 2>&1 \
     || return 2
   return $?
@@ -49,9 +49,10 @@ do_stop()
   #   1 if daemon was already stopped
   #   2 if daemon could not be stopped
   #   other if a failure occurred
-  start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --name $NAME
+  start-stop-daemon --stop --quiet --retry=TERM/30/KILL/5 --pidfile $PIDFILE --exec $DAEMON --name $NAME
   return "$?"
 }
+
 
 case "$1" in
   start)


### PR DESCRIPTION
start-stop-daemon doesn't create a pid file for the application unless it's specifically instructed to with --make-pidfile and it won't fork a process into the background unless it's instructed to with --background, so the initscript doesn't know which process to stop, and installing it on systems that use initscripts cases apt to sit there forever, just running XD. I added the required options to the initscript to fix the issue. I also changed postinst to to generate the configuration files as the debian-xd user, so the directory doesn't need to be chown'ed in the postinstall script, which lintian complains about.