### PR TITLE
fix: fix apparmor profile syntax, allow to create cache dir

### DIFF
--- a/contrib/apparmor/usr.bin.XD
+++ b/contrib/apparmor/usr.bin.XD
@@ -6,11 +6,11 @@ profile XD /usr/bin/{XD,XD-cli} {
   #include <abstractions/user-download>
 
   @{sys}/kernel/mm/transparent_hugepage/hpage_pmd_size r,
-  @{PROC}/sys/net/core/somaxcon
+  @{PROC}/sys/net/core/somaxconn r,
   /etc/mime.types r,
-
-  owner @{HOME}/.cache/XD/** r,
+  
   owner @{HOME}/.config/XD/** r,
+  owner @{HOME}/.cache/XD/{**,} rw,
   owner @{HOME}/.config/XD/metadata/{**,} rw,
 
   #include if exists <local/usr.bin.XD>


### PR DESCRIPTION
Sorry, in #88 I mistyped somaxconn. Also XD should be allowed to create cache dir for himself.