### PR TITLE
Makefile: fix regression in webui target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,10 +46,10 @@ CLI ?= XD-CLI$(BINEXT)
 build: $(CLI)
 
 
-$(XD): webui
+$(XD): $(WEBUI_CORE)
 	$(GO) build -a -ldflags "-X xd/lib/version.Git=$(GIT_VERSION)" -tags='$(TAGS)' -o $(XD)
 
-dev: webui
+dev: $(WEBUI_CORE)
 	$(GO) build -race -v -a -ldflags "-X xd/lib/version.Git=$(GIT_VERSION)" -tags='$(TAGS)' -o $(XD)
 
 $(CLI): $(XD)
@@ -80,9 +80,9 @@ $(WEBUI_LOGO):
 
 $(WEBUI_CORE): $(WEBUI_LOGO)
 	$(MAKE) -C $(WEBUI)
+	$(CP) $(WEB_FILES) $(REPO)/lib/rpc/assets/
 
 webui: $(WEBUI_CORE)
-	$(CP) $(WEB_FILES) $(REPO)/lib/rpc/assets/
 
 no-webui:
 	$(GO) build -ldflags "-X xd/lib/version.Git=$(GIT_VERSION)" -o $(XD)


### PR DESCRIPTION
The issue in the webui target that was fixed in commit 6b4204e162cef15afcf3e53634c132c78a50f3e5 was reintroduced as a regression by commit 2bdc043e090a7f4b148b4b8cd72fcf9caf9ac577.

Refer to commit 2bdc043e090a7f4b148b4b8cd72fcf9caf9ac577 for a description of the issue.
