### PR TITLE
Fix typo in install target of Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,5 +85,5 @@ no-webui:
 
 install: $(XD) $(CLI)
 	$(MKDIR) $(PREFIX)/bin
-	$(INSTALL) XD $(PREFIX)/bin
+	$(INSTALL) $(XD) $(PREFIX)/bin
 	$(CPLINK) $(CLI) $(PREFIX)/bin


### PR DESCRIPTION
Hello! This is just to fix a small typo in the Makefile (replacing hard-coded `XD` with variable `$(XD)`, like in the rest of the Makefile).