### PR TITLE
Delete leftover empty directories when moving a torrent to seeding

### DIFF
--- a/lib/storage/fs.go
+++ b/lib/storage/fs.go
@@ -77,6 +77,9 @@ func (t *fsTorrent) MoveTo(other string) (err error) {
 			}
 		}
 	}
+	// Remove empty parent directories from old location
+	t.st.FS.RemoveAll(t.FilePath())
+
 	s := t.st.getSettings(t.ih)
 	s.Put("dir", other)
 	t.st.putSettings(t.ih, s)


### PR DESCRIPTION
At the moment, when a torrent finishes downloading and is moved to the seeding directory, all the old directory structure is left behind. This PR fixes it by removing the old directory in its entirety.